### PR TITLE
Set default host to http://0.0.0.0.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://yourdomain.com" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll
+host: 0.0.0.0
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Now, running 'jekyll serve' from the command line on your VM should let you see the generated site at http://0.0.0.0:4000.