### PR TITLE
Close #199: add image to main blog content, update blog template

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,18 +16,16 @@ layout: default-minus-hero
 
     <article class="post-content">
     	<div class="container-fluid">
-	    	{% if page.image %}
 	    	<div class="row">
 	    		<div class="col-md-7">
 	      			{{ content }}
 	      		</div>
 	      		<div class="col-md-5">
+            {% if page.image %}
 	      			<img src="{{site.baseurl}}/assets/images/blog/{{ page.image }}">
+            {% endif %}
 	      		</div>
 	  		</div>
-	  		{% else %}
-	  			{{ content }}
-	    	{% endif %}
     	</div>
     </article>
   </div>

--- a/_posts/2016-5-1-scholarship-winners.markdown
+++ b/_posts/2016-5-1-scholarship-winners.markdown
@@ -3,7 +3,6 @@ layout: post
 title:   Meet the Finalists and Winner of the 2016 PiE Alumni Scholarship!
 date:   2016-5-01 22:11:17,
 categories: 2016, scholarship
-image: ''
 author: Jessica Wong
 ---
 <img src="{{site.baseurl}}/assets/images/blog/scholarship_env_2016.jpg">

--- a/blog/index.html
+++ b/blog/index.html
@@ -15,18 +15,16 @@ hero-message: PiE Blog
 
     <article class="post-content">
     	<div class="container-fluid">
-	    	{% if page.image %}
 	    	<div class="row">
 	    		<div class="col-md-7">
 	      			{{ page.content }}
 	      		</div>
 	      		<div class="col-md-5">
+            {% if page.image %}
 	      			<img src="{{site.baseurl}}/assets/images/blog/{{ page.image }}">
+            {% endif %}
 	      		</div>
 	  		</div>
-	  		{% else %}
-	  			{{ page.content }}
-	    	{% endif %}
     	</div>
     </article>
   </div>


### PR DESCRIPTION
Blogs now no longer need to have the "image" field. If you don't like having an image on the right of the text, just don't include the "image" field in the header (see [May 1, 2016 post](https://github.com/pioneers/website/blob/master/_posts/2016-5-1-scholarship-winners.markdown) for an example).