### PR TITLE
Add trailing slash to permalink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ license: >
   <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://pioneers.berkeley.edu" # the base hostname & protocol for your site
-permalink: /blog/:year/:month/:day/:title
+permalink: /blog/:year/:month/:day/:title/
 twitter_username: PieRobotics
 github_username: pioneers
 facebook_username: pierobotics


### PR DESCRIPTION
This fixes a bug I found while testing #239 in my GitHub pages site, where blog post urls with trailing slashes (like the one Doug wanted fixed) would lead to a 404 page. Blog post urls without trailing slashes still work as well after this change.

This affects Jekyll 3 and up: https://github.com/jekyll/jekyll/issues/4440