### PR TITLE
Added margins to /programs/rc-fall

### DIFF
--- a/_sass/_styles.scss
+++ b/_sass/_styles.scss
@@ -522,6 +522,11 @@ Does not work on round things. */
   color: $pie-blue;
 }
 
+.notecard{
+  margin-left: 50px;
+  margin-right: 50px;
+}
+
 .rc-spring {
   .row {
     padding-bottom: $spacing-unit;


### PR DESCRIPTION
Changes to notepad class in `_sass/_styles.csss`, adds margins to make `rc-fall` page look nicer.