### PR TITLE
Clean up image styles a bit for team/gallery/past participants.

### DIFF
--- a/_includes/gallery-image.html
+++ b/_includes/gallery-image.html
@@ -7,7 +7,7 @@
 <a href="{{ img_fullurl }}" data-toggle="lightbox" data-gallery="{{ include.gallery }}" data-title="{{ include.img_caption }}">
   <div class="staff-member">
     <div class="staff-image">
-      <img src="{{ img_fullurl }}" alt="{{ include.img_caption }}">
+      <img src="{{ img_fullurl }}" alt="{{ include.img_caption }}" class="img-scaled-wh">
     </div>
   </div>
 </a>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -8,15 +8,30 @@ body {
 /*
  * Images
  */
+.img-contain-w {
+  object-fit: contain;
+  width: 100%;
+}
+
+.img-contain-h {
+  object-fit: contain;
+  height: 100%;
+}
+
 .img-scaled-wh {
   object-fit: cover;
   height: 100%;
   width: 100%;
 }
 
-// For the school logos on the Robotics Compeition page.
-.object-contain .img-scaled-wh {
-  object-fit: contain;
+.img-scaled-w {
+  object-fit: cover;
+  width: 100%;
+}
+
+.img-scaled-h {
+  object-fit: cover;
+  height: 100%;
 }
 
 .vertical-align {

--- a/_sass/_styles.scss
+++ b/_sass/_styles.scss
@@ -65,11 +65,12 @@ Does not work on round things. */
     width: 200px;
     height: 200px;
     overflow: hidden;
-    background-color: #E6E6E6;
     margin: 0 auto 10px;
     img {
-      @extend .img-scaled-wh;
       background-color: white;
+      position: relative;
+      top: 50%;
+      transform: translateY(-50%);
     }
   }
   .staff-description {

--- a/about/team.html
+++ b/about/team.html
@@ -21,7 +21,7 @@ hero-button-url: ../get-involved/join-staff.html
             {% for member in site.data.leadership %}
             <div class="staff-member">
               <div class="staff-image">
-                <img src="../assets/images/team/{{ member.picture }}" alt="">
+                <img src="../assets/images/team/{{ member.picture }}" alt="" class="img-scaled-wh">
               </div>
               <div class="staff-description">
                 <p>{{ member.name }}</p>
@@ -38,7 +38,7 @@ hero-button-url: ../get-involved/join-staff.html
             {% for member in site.data.project-managers %}
             <div class="staff-member">
               <div class="staff-image">
-                <img src="../assets/images/team/{{ member.picture }}" alt="">
+                <img src="../assets/images/team/{{ member.picture }}" alt="" class="img-scaled-wh">
               </div>
               <div class="staff-description">
                 <p>{{ member.name }}</p>
@@ -55,7 +55,7 @@ hero-button-url: ../get-involved/join-staff.html
             {% for advisor in site.data.advisors %}
             <div class="staff-member">
               <div class="staff-image">
-                <img src="../assets/images/team/{{ advisor.picture }}" alt="">
+                <img src="../assets/images/team/{{ advisor.picture }}" alt="" class="img-scaled-wh">
               </div>
               <div class="staff-description">
                 <p>{{ advisor.name }}</p>
@@ -70,7 +70,7 @@ hero-button-url: ../get-involved/join-staff.html
             {% for alumnus in site.data.alumni %}
             <div class="staff-member">
               <div class="staff-image">
-                <img src="../assets/images/team/{{ alumnus.picture }}" alt="">
+                <img src="../assets/images/team/{{ alumnus.picture }}" alt="" class="img-scaled-wh">
               </div>
               <div class="staff-description">
                 <p>{{ alumnus.name }}</p>

--- a/compete/past-participants.html
+++ b/compete/past-participants.html
@@ -4,11 +4,11 @@ hero-image: url(../assets/images/stock-images/team-1.jpg)
 hero-message: Past Participants
 ---
 
-<div class="row text-center object-contain" id="alumni">
+<div class="container" id="alumni">
   <div class="staff-images">
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Alacanes.JPG' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Alacanes.JPG' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Acalanes High School</p>
@@ -16,7 +16,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/AlamedaCLC.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/AlamedaCLC.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Alameda Community Learning Center</p>
@@ -24,7 +24,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Alameda.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Alameda.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Alameda High School</p>
@@ -32,7 +32,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Albany.gif' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Albany.gif' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Albany High School</p>
@@ -40,8 +40,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Arroyo.jpg' | prepend: site.baseurl }}" alt="">
-" alt="">
+        <img src="{{ '/assets/images/schools/Arroyo.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Arroyo High School</p>
@@ -49,7 +48,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/AspireCalPrep.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/AspireCalPrep.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Aspire California Preparatory Academy</p>
@@ -57,7 +56,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Balboa.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Balboa.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Balboa High School</p>
@@ -65,7 +64,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Berkeley.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Berkeley.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Berkeley High School</p>
@@ -73,7 +72,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/BishopODowd.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/BishopODowd.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Bishop O'Dowd High School</p>
@@ -81,7 +80,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/CommunityDay.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/CommunityDay.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Community Day High School</p>
@@ -89,7 +88,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/DeAnza.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/DeAnza.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>De Anza High School</p>
@@ -97,7 +96,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/ElCerrito.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/ElCerrito.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>El Cerrito High School</p>
@@ -105,7 +104,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Encinal.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Encinal.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Encinal High School</p>
@@ -113,7 +112,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Galileo.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Galileo.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Galileo High School</p>
@@ -121,7 +120,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/HeadRoyce.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/HeadRoyce.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Head-Royce High School</p>
@@ -129,7 +128,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Hercules.gif' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Hercules.gif' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Hercules High School</p>
@@ -137,7 +136,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Impact.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Impact.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Impact Academy</p>
@@ -145,7 +144,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/LawrenceHallofScience.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/LawrenceHallofScience.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Lawrence Hall of Science TEAMS</p>
@@ -153,7 +152,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/LeadershipPublic.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/LeadershipPublic.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Leadership Public Schools Richmond</p>
@@ -161,7 +160,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/LighthouseCC.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/LighthouseCC.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Lighthouse Community Charter School</p>
@@ -169,7 +168,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/LionelWilsonCPA.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/LionelWilsonCPA.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Lionel Wilson College Preparatory Academy</p>
@@ -177,7 +176,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/McClymonds.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/McClymonds.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>McClymonds High School</p>
@@ -185,7 +184,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/MetWest.jpg' | prepend: site.baseurl }}"alt="">
+        <img src="{{ '/assets/images/schools/MetWest.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>MetWest High School</p>
@@ -193,7 +192,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/MiCHS.JPG' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/MiCHS.JPG' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Middle College High School</p>
@@ -201,7 +200,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/NeaCLC.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/NeaCLC.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Nea Community Learning Center</p>
@@ -209,7 +208,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/OaklandSA.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/OaklandSA.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Oakland School for the Arts</p>
@@ -217,7 +216,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/OaklandTech.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/OaklandTech.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Oakland Technical High School</p>
@@ -225,7 +224,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/PinoleValley.gif' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/PinoleValley.gif' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Pinole Valley High School</p>
@@ -233,7 +232,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/RalphBunche.png' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/RalphBunche.png' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Ralph Bunche High School</p>
@@ -241,7 +240,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Realm.bmp' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Realm.bmp' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Realm Charter High School</p>
@@ -249,7 +248,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/StMarysCollege.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/StMarysCollege.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Saint Mary's College High School</p>
@@ -257,7 +256,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/SanLorenzo.gif' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/SanLorenzo.gif' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>San Lorenzo High School</p>
@@ -265,7 +264,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/Skyline.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/Skyline.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Skyline High School</p>
@@ -273,7 +272,7 @@ hero-message: Past Participants
     </div>
     <div class="staff-member">
       <div class="staff-image">
-        <img src="{{ '/assets/images/schools/RaoulWallenberg.jpg' | prepend: site.baseurl }}" alt="">
+        <img src="{{ '/assets/images/schools/RaoulWallenberg.jpg' | prepend: site.baseurl }}" alt="" class="img-contain-w">
       </div>
       <div class="staff-description">
         <p>Raoul Wallenberg High School</p>


### PR DESCRIPTION
The way images are treated in the Past Participants page is a bit different than the way they're treated in the Gallery and Team pages, although the overall layout is very similar. Rather than override styles to get the correct image scaling behavior, I separated out these rules into other CSS classes and applied the classes in the HTML.