### PR TITLE
Enable Travis CI to check website compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ _site/*
 .jekyll-metadata
 .DS_Store
 ._*
-*.lock
 *.un*
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+rvm:
+  - 2.5.1
+
+script: ./script/htmlproofer.sh
+
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+
+sudo: false # route your build to the container-based infrastructure for a faster build
+
+cache: bundler # caching bundler gem packages will speed up build
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rvm:
   - 2.5.1
 
 script: ./script/htmlproofer.sh
+  - bundle exec jekyll build
+# If we want to check our website too, uncomment the line below
+# - ./script/htmlproofer.sh
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.5.1
 
-script: ./script/htmlproofer.sh
+script: 
   - bundle exec jekyll build
 # If we want to check our website too, uncomment the line below
 # - ./script/htmlproofer.sh

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll', '~>3.8'
 gem 'html-proofer', '>=3.9.0'
+gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '~>3.8'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 gem 'jekyll', '~>3.8'
 gem 'html-proofer', '>=3.9.0'
-gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~>3.8'
+gem 'html-proofer', '>=3.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,63 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.0.5)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.9.25)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.8.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-watch (2.0.0)
+      listen (~> 3.0)
+    kramdown (1.17.0)
+    liquid (4.0.0)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    mercenary (0.3.6)
+    pathutil (0.16.1)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.2)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (3.1.1)
+    ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
+    sass (3.5.6)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (~> 3.8)
+
+BUNDLED WITH
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
+    colorize (0.8.1)
     concurrent-ruby (1.0.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.7)
     ffi (1.9.25)
     forwardable-extended (2.6.0)
+    html-proofer (3.9.1)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.8.1)
+      parallel (~> 1.3)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -38,6 +55,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    nokogiri (1.8.3)
+      mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.2)
@@ -52,11 +74,18 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    thread_safe (0.3.6)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer (>= 3.9.0)
   jekyll (~> 3.8)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.2)
-    rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -88,7 +87,6 @@ PLATFORMS
 DEPENDENCIES
   html-proofer (>= 3.9.0)
   jekyll (~> 3.8)
-  rake
 
 BUNDLED WITH
    1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.2)
+    rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -87,6 +88,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer (>= 3.9.0)
   jekyll (~> 3.8)
+  rake
 
 BUNDLED WITH
    1.16.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'html-proofer'
+
+task :test do
+  sh "bundle exec jekyll build"
+  options = { :assume_extension => true }
+  HTMLProofer.check_directory("./_site", options).run
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,0 @@
-require 'html-proofer'
-
-task :test do
-  sh "bundle exec jekyll build"
-  options = { :assume_extension => true }
-  HTMLProofer.check_directory("./_site", options).run
-end

--- a/_includes/sitemap.html
+++ b/_includes/sitemap.html
@@ -35,17 +35,17 @@
         <ul>
           <li> <p class="sitemap-header"> Get Involved </p> </li>
           <li> <a class="sitemap" href="/get-involved/index"> Join PiE Staff </a> </li>
-          <li> <a class="sitemap" href="/get-involved/projects"> Projects </a> </li>
+          <li> <a class="sitemap" href="/get-involved/#projects"> Projects </a> </li>
           <li> <a class="sitemap" href="/get-involved/become-mentor"> Mentor (Decal) </a> </li>
-          <li> <a class="sitemap" href="/get-involved/volunteer"> Volunteer </a> </li>
-          <li> <a class="sitemap" href="/get-involved/faq"> FAQ </a> </li>
+          <li> <a class="sitemap" href="/get-involved/#volunteer"> Volunteer </a> </li>
+          <li> <a class="sitemap" href="/get-involved/#faq"> FAQ </a> </li>
         </ul>
       </div>
       <div class="col-sm-2 col-xs-6">
         <ul>
           <li> <p class="sitemap-header"> Support PiE </p> </li>
-          <li> <a class="sitemap" href="../support-pie/"> How You Can Help</a> </li>
-          <li> <a class="sitemap" href="../support-pie/#sponsors"> List of Sponsors </a> </li>
+          <li> <a class="sitemap" href="/support-pie/"> How You Can Help</a> </li>
+          <li> <a class="sitemap" href="/support-pie/#sponsors"> List of Sponsors </a> </li>
         </ul>
        </div>
       <div class="col-sm-2 col-xs-6">

--- a/script/docker-build.sh
+++ b/script/docker-build.sh
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+# This is not meant to be run from within script/
+docker build -t pie-website .;

--- a/script/docker-dev.sh
+++ b/script/docker-dev.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+docker run -i --rm -p 4000:4000 -v "$PWD:/srv/jekyll" numascott/jekylldev:latest serve --incremental
+
+# Breaking it down
+
+# docker run ... numascott/jekylldev:latest
+# create a container from the latest numascott/jekyll image
+# https://hub.docker.com/r/numascott/jekylldev/
+
+# -i
+# Use interactive mode so that the output from jekyll is displayed
+
+# --rm
+# After exiting, delete the stopped container to keep our Docker space clean
+
+# 4000:4000
+# Map port 4000 inside the Docker container to port 4000 inside our computer
+
+# -v "$PWD:/srv/jekyll"
+# Allow the current folder of PWD be accessible inside the Docker container
+# inside the folder /srv/jekyll. The quotes are necessary to address folder
+# names that contain characters such as spaces.
+
+# The files inside the container will change as you change them in the current
+# folder

--- a/script/htmlproofer.sh
+++ b/script/htmlproofer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle exec jekyll build
+bundle exec htmlproofer ./_site

--- a/script/htmlproofer.sh
+++ b/script/htmlproofer.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site
+bundle exec htmlproofer --assume-extension ./_site


### PR DESCRIPTION
- Add Gemfile to standardize development environment
- [Add .travis.yml to check website compilation](https://travis-ci.org/scottnuma/website/builds/398519836)
- Configure Htmlproofer to check website. There's a lot of [broken links](https://travis-ci.org/scottnuma/website/builds/398519505) as well as standards we don't follow (warrants a larger discussion by the web-involved team). Currently not part of continuous integration, but might be good to have in the future.