### PR TITLE
Update Runtime intructions

### DIFF
--- a/software/index.html
+++ b/software/index.html
@@ -51,6 +51,7 @@ runtime-last-update: April 29, 2018
 </ul>
 
 <h2>Updating Runtime</h2>
+<i><p style="font-size:18px">Please only update Runtime if instructed by PiE Staff or if the Runtime section at the top of the page says to update.</p></i>
 <div class="row">
   <div class="col-md-6">
  <ol style="padding-left:45px;font-size:18px">


### PR DESCRIPTION
The original instructions for updating Runtime lacked an explanation for when to update. I basically added the condition "when told to" because some students thought you had to do it day one.