### PR TITLE
Fix Bundler Errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 
 script: 
   - bundle exec jekyll build
+  - docker build -t website:latest .
 # If we want to check our website too, uncomment the line below
 # - ./_script/htmlproofer.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update -qq && apt-get install -y build-essential
 ADD Gemfile /srv/jekyll/Gemfile
 ADD Gemfile.lock /srv/jekyll/Gemfile.lock
 
+# Use Bundler 2
+ENV BUNDLER_VERSION 2.0.2
+RUN gem install bundler
+
 # Use this folder as dir we will work from
 WORKDIR /srv/jekyll
 
@@ -24,7 +28,6 @@ ADD . /srv/jekyll
 
 # Build the website
 RUN bundle exec jekyll build
-
 
 # Serve the website when we run the image
 CMD bundle exec jekyll serve

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,4 +1,0 @@
-#! /usr/bin/env bash
-
-docker build -t pie-website .;
-docker run -d --name website -p 4000:4000 pie-website

--- a/docker-dev.sh
+++ b/docker-dev.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+set -e
 
 CONTAINER_NAME="website"
 


### PR DESCRIPTION
- Use Bundler 2 in the docker image through explicit upgrade
- Update `docker-dev.sh` to exit upon error to make it easier to catch
- Test building the image in Travis to make it less likely to hit master