### PR TITLE
Swap Paypal button for Donorbox button

### DIFF
--- a/support-pie/index.html
+++ b/support-pie/index.html
@@ -35,14 +35,9 @@ title: Support PiE
 			<p>With our yearly fundraising goal of $75,000, Pioneers in Engineering is actively seeking support from corporations and philanthropic organizations. In addition, PiE appreciates and accepts in-kind gifts in the form of parts and tools to complete the robotics kits. Donations to PiE are 501(c)(3) tax-deductible.</p>
 			<p>If you would like more information about PiE and how to partner with us, please email <a href="mailto:partnerships@pioneers.berkeley.edu">partnerships@pioneers.berkeley.edu</a>.</p>
 		</div>
-		<div class="col-md-4 text-center">
-			<img id="paypal" src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/PP_logo_h_200x51.png" alt="PayPal" />
-			<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-				<input type="hidden" name="cmd" value="_s-xclick">
-				<input type="hidden" name="hosted_button_id" value="XC8EQT355DC32">
-				<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-				<img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-			</form>
+		<div class="col-md-4 text-center" style="padding-top: 20px">
+            <script type="text/javascript" defer src="https://donorbox.org/install-popup-button.js"></script>
+            <a class="dbox-donation-button" style="background: #41A2D8 url(https://d1iczxrky3cnb2.cloudfront.net/red_logo.png) no-repeat 37px;color: #fff;text-decoration: none;font-family: Verdana,sans-serif;display: inline-block;font-size: 16px;padding: 15px 38px;padding-left: 75px;-webkit-border-radius: 2px;-moz-border-radius: 2px;border-radius: 2px;box-shadow: 0 1px 0 0 #1F5A89;text-shadow: 0 1px rgba(0, 0, 0, 0.3);" href="https://donorbox.org/pioneers-in-engineering">Donate</a>
 		</div>
 	</div>
 	<div class="row">


### PR DESCRIPTION
Swap Paypal button for Donorbox, which provides more payment options as well as a cleaner UI

Button on page
<img width="624" alt="Donation Page with DonorBox Button" src="https://user-images.githubusercontent.com/1498615/102171340-2a6a2200-3e4b-11eb-8e37-4635f195fe68.png">

Modal after clicking on button
<img width="624" alt="Donation Page with Donorbox Modal" src="https://user-images.githubusercontent.com/1498615/102171684-fe9b6c00-3e4b-11eb-99bb-f2b25d197c8c.png">

