### PR TITLE
Fix macOS installation

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "vendor/bundle"
+BUNDLE_WITHOUT: "test"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+vendor/
 _site/*
 .sass-cache/*
 .jekyll-metadata
+.jekyll-cache/
 .DS_Store
 ._*
 *.un*

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /srv/jekyll
 ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
 
-# Use Bundler 2 with out config
+# Use Bundler 2 without config
 ADD .bundle .bundle
 ENV BUNDLER_VERSION 2.0.2
 RUN gem install bundler

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,17 @@ MAINTAINER Scott Numamoto <scott.numamoto@pioneers.berkeley.edu>
 # Install bundler for dependency management
 RUN apt-get update -qq && apt-get install -y build-essential
 
-# Copy over the Gemfile. This reduces effort required to re-build
-ADD Gemfile /srv/jekyll/Gemfile
-ADD Gemfile.lock /srv/jekyll/Gemfile.lock
-
-# Use Bundler 2
-ENV BUNDLER_VERSION 2.0.2
-RUN gem install bundler
-
 # Use this folder as dir we will work from
 WORKDIR /srv/jekyll
+
+# Copy over the Gemfile. This reduces effort required to re-build
+ADD Gemfile Gemfile
+ADD Gemfile.lock Gemfile.lock
+
+# Use Bundler 2 with out config
+ADD .bundle .bundle
+ENV BUNDLER_VERSION 2.0.2
+RUN gem install bundler
 
 # Install dependencies
 RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,8 @@ source 'https://rubygems.org'
 ruby "~>2.6.3"
 
 gem 'jekyll', '>=3.8.6'
-gem 'html-proofer', '>=3.10.0'
+
+group :test do
+  gem 'nokogiri'
+  gem 'html-proofer', '>=3.10.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
 
 PLATFORMS
   universal-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   html-proofer (>= 3.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-linux)
+      racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.20.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,16 +4,16 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    ffi (1.14.2)
+    ffi (1.15.1)
     forwardable-extended (2.6.0)
-    html-proofer (3.18.5)
+    html-proofer (3.19.1)
       addressable (~> 2.3)
       mercenary (~> 0.3)
       nokogumbo (~> 2.0)
@@ -22,7 +22,7 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.8)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jekyll (4.2.0)
       addressable (~> 2.4)
@@ -48,13 +48,15 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.4.1)
+    listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.11.1-x86_64-linux)
+    nokogiri (1.11.7-arm64-darwin)
       racc (~> 1.4)
-    nokogumbo (2.0.4)
+    nokogiri (1.11.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.20.1)
     pathutil (0.16.2)
@@ -62,7 +64,7 @@ GEM
     public_suffix (4.0.6)
     racc (1.5.2)
     rainbow (3.0.0)
-    rb-fsevent (0.10.4)
+    rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
@@ -78,14 +80,15 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  x86_64-linux
+  universal-darwin-20
 
 DEPENDENCIES
   html-proofer (>= 3.10.0)
   jekyll (>= 3.8.6)
+  nokogiri
 
 RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.2.9
+   2.2.15


### PR DESCRIPTION
- macOS installation broke due to nokogiri. nokogiri is no fun to  install because it is a chonker of a package and has an involved installation process
- Move nokogiri and htmlproofer into the test group because they are used for testing
- Do not install these packages by default, also do not install in Docker
- Update the packages while we're at it