### PR TITLE
Deploy to master w/ new release- tag

### DIFF
--- a/.github/workflows/push-production.yml
+++ b/.github/workflows/push-production.yml
@@ -1,0 +1,24 @@
+
+name: 'deploy-production'
+
+on:
+  # Triggers the workflow on branch and tag creation events
+  create:
+
+jobs:
+  deploy_production:
+    # Only deploy if it has the tag 'release'
+    if: ${{ startsWith(github.ref, 'refs/tags/release') }}
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          git_remote_url: 'ssh://dokku@apple.pierobotics.org:22/website'
+          ssh_private_key: ${{ secrets.DOKKU_WEBSITE_PRIVATE_KEY }}


### PR DESCRIPTION
- Previously, we created a GitHub workflow to deploy to staging when we create a release with the `release` prefix and then an authorized approver approves
- Let's do the same, but now for prod
- Example flow: 
  - Developer merges PR and creates a new release: `release-something`
  - Admin approves deploying staging
  - The deploy-staging workflow runs and the change is live on staging-website.pierobotics.org
  - Developer verifies change
  - Admin approves deploying production
  - The deploy-production workflow runs and the change is live on pioneers.berkeley.edu